### PR TITLE
Connor Horman's sample chapter (arrays/slices)

### DIFF
--- a/spec/lang/exprs/array.md
+++ b/spec/lang/exprs/array.md
@@ -1,0 +1,34 @@
+## Array Construction [exprs.array]
+
+Syntax:
+```abnf 
+array-expr := "[" [<expr> [*("," <expr>)] [","] ] "]"
+
+simple-expr /= <array-expr>
+```
+
+1. Constraints: Each `expr` must, after implicit coercions, have the same type `T` such that `T: core::marker::Sized`.
+
+2. The array-expr `[E0, E1, .., En]` constructs the `n` element array of type `T`, such that the `i`th element of the resulting array is equivalent to `Ei` for `0<=i<n`. 
+
+3. Given the array-expr `[E0, E1, .., En]`, each `Ei` for `0<=i<n` is a value expression, and the array-expr is a value expression.
+
+4. An array-expr is ill-formed if `n` is not representible as a value of type `usize`, or if the size of the resulting array type is greater than `isize::MAX as usize`.
+
+
+Syntax:
+```abnf
+repeat-expr := "[" <expr> ";" <expr> "]"
+
+simple-expr /= <repeat-expr>
+```
+
+1. Constraints: Given the repeat-expr `[val ; N]`,  `N` shall be a *potentially-dependant* constant expression of `usize`, and `val` shall be of a type `T`, such that `T: core::marker::Sized`. If `N` is a *dependent constant expression* or `N > 2`, then either `T: core::marker::Copy` or `val` shall be a (potentially parenthesized) path-expr that denotes a const item. 
+
+2. The repeat-expr `[val;N]` constructs the `N` element array of type `T`, such that the `i`th element of the resulting array is equivalent to `val`, for `0<=i<N`. 
+
+3. If `N` is equal to zero, then `val` is dropped. If `N` is equal to 1, then `val` is evaluated exactly once as the sole element of the resulting array. Otherwise, if `val` is a (potentially parenthesized) path-expr that denotes a const item, then it is evaluated `N` times to initialize each corresponding element of the array. Otherwise, `val` is evaluated exactly once, and copied to each element of the array. 
+
+4. Given the repeat-expr `[val;N]`, `val` is a value expression, and the resulting repeat-expr is a value expression.
+
+5. A repeat-expr is ill-formed if the size of the resulting array type is greater than `isize::MAX as usize`.

--- a/spec/lang/exprs/array.md
+++ b/spec/lang/exprs/array.md
@@ -15,6 +15,10 @@ simple-expr /= <array-expr>
 
 4. An array-expr is ill-formed if `n` is not representible as a value of type `usize`, or if the size of the resulting array type is greater than `isize::MAX as usize`.
 
+[Note 1: The latter constraint means that the effectively largest `n` is `isize::MAX`, unless `T` is a zero-sized type. Types larger than 1 byte further constraint `n`]
+
+5. If all of `E0, E1, .., En` are *constant expressions*, then `[E0, E1, .., En]` is a *constant expression*.
+
 
 Syntax:
 ```abnf
@@ -32,3 +36,8 @@ simple-expr /= <repeat-expr>
 4. Given the repeat-expr `[val;N]`, `val` is a value expression, and the resulting repeat-expr is a value expression.
 
 5. A repeat-expr is ill-formed if the size of the resulting array type is greater than `isize::MAX as usize`.
+
+[Note 1: The latter constraint means that the effectively largest `N` is `isize::MAX`, unless `T` is a zero-sized type. Types larger than 1 byte further constraint `n`]
+
+6. If `val` is a *constant expression*, then `[val; N]` is a *constant expression*.
+

--- a/spec/lang/exprs/index.md
+++ b/spec/lang/exprs/index.md
@@ -11,12 +11,17 @@ suffix-expr /= <index-expr>
 
 2. The index-expr `base[idx]` accesses element `idx` of the array `base`. `base` is a place expression, and `idx` is a value expression. Deref coercions are applied to `base` (`[coercion.deref]`). 
 
-3. If `base` is of an array or slice type, then `idx`, after implicit coercions, must be of type `usize`. If `idx` is greater than or equal to the length of the length of the array or slice, the expression panics with an unspecified message that contains both the value `idx` and the length of the array. Otherwise, the result is a place that refers to the `idx` element of the array or slice `base`. 
+3. If `base` is *pre-mono known* to be of of an array or slice type, and `idx`, after implicit coercions, is *pre-mono known* be of type `usize`. If `idx` is greater than or equal to the length of the length of the array or slice, the expression panics with an unspecified message that contains both the value `idx` and the length of the array. Otherwise, the result is a place that refers to the `idx` element of the array or slice `base`. 
+
+[Note 1: Arrays are index from `0`, so the first element of the array is index `0`, the second index `2`, etc. The index `N` is out of bounds for an array of length `N`]
 
 4. If `base` is not of an array or slice type, or `idx` is not of type `usize`, then the result of the expression is the same as either `*(<T as core::ops::Index::<U>>::index(&base, idx))` or `*(<T as core::ops::IndexMut<U>>::index_mut(&mut base,idx))` except that implicit coercions are not applied to `idx` unless the *implementor-set* for `T as core::ops::Index` contains only one element. 
+
+[Note 2: The type `[T]` implements both the `core::ops::Index<U>` and `core::ops::IndexMut<U>` trait when `U` is a builtin-range type. The behaviour of these trait implementations are described in the library specification and are not documented here. Additionally the type `[T]` implements both the `core::ops::Index<usize>` and `core::ops::IndexMut<usize>` traits. The behaviour of these impls is to perform the operation described in (3). These impls are not used by an index-expr if `base` and `idx` are both *pre-mono known* to be an array or slice type and `usize` respectively.]
 
 5. The resulting place is mutable if and only if `base` is mutable. The resulting place is not movable. If `base` is not of an array or slice type, the result is given by the call to `index_mut` if and only if the resulting place is (possibly as a subexpression of an index-expr, field-access-expr, or method-invocation-expr) assigned to or is mutably borrowed, otherwise the result is given by the call to `index`. 
 
 6. If `base` is of an array or slice type, and `idx` is of type `usize`, the behaviour is undefined if the offset of the `idx` element from the start of `base` is not inbounds of an allocation referred to by `base`, and `idx` is less than the length of the array or slice.
+
 
 7. If `base` is of an array or slice type, and `idx` is of type `usize`, then `base[idx]` is a *constant expression* if `base` and `idx` are both *constant expressions*. 

--- a/spec/lang/exprs/index.md
+++ b/spec/lang/exprs/index.md
@@ -1,0 +1,22 @@
+## Array Indexing [exprs.index]
+
+Syntax:
+```abnf
+index-expr := <suffix-expr> "[" <expr> "]"
+
+suffix-expr /= <index-expr>
+```
+
+1. Constraints: given the index-expr `base[idx]`, either `base`, shall be an expression of an array or slice type and `idx` shall be an expression of type `usize`, or `base` shall be of a type `T` and `sub` shall be of a type `U`, such that `T: core::ops::Index<U>`.
+
+2. The index-expr `base[idx]` accesses element `idx` of the array `base`. `base` is a place expression, and `idx` is a value expression. Deref coercions are applied to `base` (`[coercion.deref]`). 
+
+3. If `base` is of an array or slice type, then `idx`, after implicit coercions, must be of type `usize`. If `idx` is greater than or equal to the length of the length of the array or slice, the expression panics with an unspecified message that contains both the value `idx` and the length of the array. Otherwise, the result is a place that refers to the `idx` element of the array or slice `base`. 
+
+4. If `base` is not of an array or slice type, or `idx` is not of type `usize`, then the result of the expression is the same as either `*(<T as core::ops::Index::<U>>::index(&base, idx))` or `*(<T as core::ops::IndexMut<U>>::index_mut(&mut base,idx))` except that implicit coercions are not applied to `idx` unless the *implementor-set* for `T as core::ops::Index` contains only one element. 
+
+5. The resulting place is mutable if and only if `base` is mutable. The resulting place is not movable. If `base` is not of an array or slice type, the result is given by the call to `index_mut` if and only if the resulting place is (possibly as a subexpression of an index-expr, field-access-expr, or method-invocation-expr) assigned to or is mutably borrowed, otherwise the result is given by the call to `index`. 
+
+6. If `base` is of an array or slice type, and `idx` is of type `usize`, the behaviour is undefined if the offset of the `idx` element from the start of `base` is not inbounds of an allocation referred to by `base`, and `idx` is less than the length of the array or slice.
+
+7. If `base` is of an array or slice type, and `idx` is of type `usize`, then `base[idx]` is a *constant expression* if `base` and `idx` are both *constant expressions*. 

--- a/spec/lang/types/array.md
+++ b/spec/lang/types/array.md
@@ -20,4 +20,4 @@ type /= <array-type> / <slice-type>
 
 6. The metadata of the slice type `[T]` is `usize`, regardless of `T`. The metadata value stores the number of elements of the slice. The size of a value of type `[T]`, given the metadata value is `N`, is `N` times the size of `T`. 
 
-7. An array type `[T;N]` unsizes to the sl
+7. An array type `[T;N]` unsizes to the slice type `[T]`. The metadata for the coercion is the value `N`. 

--- a/spec/lang/types/array.md
+++ b/spec/lang/types/array.md
@@ -1,0 +1,23 @@
+## Array Type [primitives.array]
+
+Syntax:
+```abnf
+array-type := "[" <type> ";" <expr> "]"
+slice-type := "[" <type> "]"
+
+type /= <array-type> / <slice-type>
+```
+
+1. Constraints: Given an array type `[T;N]` and a slice type `[T]`, `N` shall be a *potentially-dependant* constant expression of `usize`, and `T` shall be a type that implements `core::marker::Sized`.
+
+2. An array type, declared `[T;N]`, is a special compound type, dependent on `T` and `N`. It has `N` values of type `T` laid out contiguously in increasing order. 
+
+3. An Array type `[T;N]` is a *statically-sized type*, regardless of `N` or `T`. `T` shall be a *statically-sized type*. The alignment requirement of `[T;N]` is the alignment requirement of `T`, and the size of `[T;N]` is `N` times the size of `T`. 
+
+4. A slice type, declared `[T]`, is a special compound type, dependent on `T`. It has a statically unknown number of values of `T` laid out contiguously in increasing order.
+
+5. A slice type is a *statically-unsized type*, regardless of `T`. `T` shall be a *statically-sized type*. The alignment requirement of `[T]` is the alignment requirement of `T`. 
+
+6. The metadata of the slice type `[T]` is `usize`, regardless of `T`. The metadata value stores the number of elements of the slice. The size of a value of type `[T]`, given the metadata value is `N`, is `N` times the size of `T`. 
+
+7. An array type `[T;N]` unsizes to the sl


### PR DESCRIPTION
Includes `[types.array]`, `[expr.array]`, and `[expr.index]`.