### PR TITLE
Add an initial contributing doc.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing to The Rust Specification
+
+> [!WARNING]
+> The Rust Specification is still in the early days of getting started and is
+> not yet ready for outside contributors. Please get in contact with the team
+> on [Zulip] if you are interested in participating.
+
+[Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/399173-t-spec
+
+## Building
+
+See the [Building docs](README.md#building) for information on generating HTML from the specification source files.
+
+## Authoring guide
+
+See the [Authoring Guide](docs/authoring.md) for information about working with the specification source files.


### PR DESCRIPTION
This adds an initial placeholder for the contributing doc. Once things have been established more, I expect this to be extended with more information.

cc #18