### PR TITLE
Add a review policy

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -1,0 +1,38 @@
+# Spec Team
+
+## Mission
+
+## Team membership
+
+### Membership expectations
+
+#### Review policy
+
+Team members are given permission to merge changes from other contributors in the <https://github.com/rust-lang/spec> repository. There are different guidelines for reviewing based on the kind of changes being made:
+
+- Policy changes
+    - Significant changes to the policy of how the team operates, such as changes to this document, should have agreement of the team without any blocking objections.
+    - Minor changes to something like the style enforcement can be made with the review of a team member, as long as there is high confidence that it is unlikely any team member would object (for example, codifying a guideline that is already in practice), and that the change can be easily reversed.
+- Meaningful content addition or changes
+    - When adding or changing content in the spec, the reviewer should consult with appropriate experts to validate the changes. This may not be required if the reviewer has high confidence that the changes are correct, and consider themselves well-versed enough in the topic to understand it, or the relevant experts are the author or have been heavily involved in the process. It is up to the reviewer to use their best judgement when to consult.
+    - Content should always follow the guidelines from the [authoring guide].
+- Minor content changes
+    - Minor content changes, such as small cleanups or wording fixes, can be made with the review from a team member without further consultation.
+- Tooling changes
+    - Minor changes to the tooling may be made with a review from a team member. This includes bug fixes, minor additions that are unlikely to have objections, and additions that have already been discussed.
+    - Major changes, such as a change in how content is authored, or major changes to how the tooling works should be approved by the team without blocking objections.
+
+<!-- TODO -->
+This policy does not yet cover the process for getting final approval from the relevant teams.
+
+[authoring guide]: authoring.md
+
+### Meetings
+
+### Becoming a member
+
+## Team resources
+
+## Decision process
+
+## Contact


### PR DESCRIPTION
This is an attempt to try to capture what I think should be guidelines for merging and reviewing, based on some of the discussion from the 2024-03-14 meeting.

I placed this within an outline of other team documentation I think we should have to give context to where it fits in. I expect to have these other sections filled in the future.

This explicitly does not cover how "final approval" is given by teams like the lang team, which I think will need a separate process.

Closes #25
