### PR TITLE
Fix some issues with the rust-lang/rust upstream.

### DIFF
--- a/mdbook-spec/CHANGELOG.md
+++ b/mdbook-spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## mdbook-spec 0.1.2
+
+- Fixed some issues with rust-lang/rust build integration.
+
 ## mdbook-spec 0.1.1
 
 - Moved code to a library to support upstream integration.

--- a/mdbook-spec/Cargo.toml
+++ b/mdbook-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-spec"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "An mdBook preprocessor to help with the Rust specification."
@@ -13,7 +13,7 @@ anyhow = "1.0.79"
 mdbook = { version = "0.4.36", default-features = false }
 once_cell = "1.19.0"
 pathdiff = "0.2.1"
-regex = "1.10.3"
+regex = "1.9.4"
 semver = "1.0.21"
 serde_json = "1.0.113"
 tempfile = "3.10.1"

--- a/mdbook-spec/src/lib.rs
+++ b/mdbook-spec/src/lib.rs
@@ -65,7 +65,7 @@ impl Spec {
         let source_path = chapter.source_path.clone().unwrap_or_default();
         let path = chapter.path.clone().unwrap_or_default();
         RULE_RE
-            .replace_all(&chapter.content, |caps: &Captures| {
+            .replace_all(&chapter.content, |caps: &Captures<'_>| {
                 let rule_id = &caps[1];
                 if let Some((old, _)) =
                     found_rules.insert(rule_id.to_string(), (source_path.clone(), path.clone()))
@@ -127,7 +127,7 @@ impl Spec {
     /// file.
     fn admonitions(&self, chapter: &Chapter) -> String {
         ADMONITION_RE
-            .replace_all(&chapter.content, |caps: &Captures| {
+            .replace_all(&chapter.content, |caps: &Captures<'_>| {
                 let lower = caps["admon"].to_lowercase();
                 format!(
                     "<div class=\"{lower}\">\n\n{}\n\n</div>\n",
@@ -140,7 +140,7 @@ impl Spec {
 
 impl Preprocessor for Spec {
     fn name(&self) -> &str {
-        "nop-preprocessor"
+        "spec"
     }
 
     fn run(&self, _ctx: &PreprocessorContext, mut book: Book) -> Result<Book, Error> {

--- a/mdbook-spec/src/std_links.rs
+++ b/mdbook-spec/src/std_links.rs
@@ -74,7 +74,7 @@ pub fn std_links(chapter: &Chapter) -> String {
 
     // Replace any disambiguated links with just the disambiguation.
     let mut output = STD_LINK_RE
-        .replace_all(&chapter.content, |caps: &Captures| {
+        .replace_all(&chapter.content, |caps: &Captures<'_>| {
             if let Some(dest) = caps.get(2) {
                 // Replace destination parenthesis with a link definition (square brackets).
                 format!("{}[{}]", &caps[1], dest.as_str())
@@ -174,7 +174,8 @@ fn run_rustdoc(tmp: &TempDir, links: &[(&str, Option<&str>)], chapter: &Chapter)
     )
     .unwrap();
     fs::write(&src_path, &src).unwrap();
-    let output = Command::new("rustdoc")
+    let rustdoc = std::env::var("RUSTDOC").unwrap_or_else(|_| "rustdoc".into());
+    let output = Command::new(rustdoc)
         .arg("--edition=2021")
         .arg(&src_path)
         .current_dir(tmp.path())


### PR DESCRIPTION
This fixes some more issues trying to get mdbook-spec to work in rust-lang/rust.

- Regex must be downgraded because [memchr is pinned](https://github.com/rust-lang/rust/blob/bcf1f6db4594ae6132378b179a30cdb3599a863d/compiler/rustc_ast/Cargo.toml#L10) and we need to use older versions of regex because of that.
- Set the name of the preprocessor correctly (required for how it is integrated upstream).
- Added some elided lifetimes because the rust repo is finicky about using `elided_lifetimes_in_paths`.
- Don't assume `rustdoc` is in PATH, since when building it isn't there.
