### PR TITLE
Fix outdated Cargo.lock

### DIFF
--- a/mdbook-spec/Cargo.lock
+++ b/mdbook-spec/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-spec"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "mdbook",


### PR DESCRIPTION
Missed this change in #68, which is causing CI to fail.